### PR TITLE
Call 'didMoveToparentViewController' to the correct ViewController

### DIFF
--- a/FJBMenuViewController.podspec
+++ b/FJBMenuViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'FJBMenuViewController'
-  s.version  = '0.0.10'
+  s.version  = '0.0.11'
   s.platform = :ios, '6.0'
   s.summary  = 'Menu View Controller Library.'
   s.description = 'Menu View Controller library with support for animations and new configurations'

--- a/src/FJBMenuViewController.m
+++ b/src/FJBMenuViewController.m
@@ -236,7 +236,7 @@
     
     [self addChildViewController:_centerViewController];
     [self.view addSubview:_centerViewController.view];
-    [self didMoveToParentViewController:_centerViewController];
+    [_centerViewController didMoveToParentViewController:self];
     [self p_setupGestureRecognizer];
 }
 


### PR DESCRIPTION
It was calling 'didMoveToparentViewController' to self, but it's the child that is just moved. 
